### PR TITLE
Add make target for creating a dev version of the Alfred workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /alfred-swift-evolution.alfredworkflow
+/alfred-swift-evolution-dev.alfredworkflow

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,25 @@
 OUTPUT = alfred-swift-evolution.alfredworkflow
+OUTPUT_DEV = alfred-swift-evolution-dev.alfredworkflow
 FILES = Info.plist se-lookup.swift icon.png
 
 all: $(OUTPUT)
 
+# Build a development version of the workflow with a different bundle ID.
+# Useful for testing changes in Alfred without replacing the production version.
+dev: $(OUTPUT_DEV)
+
 clean:
-	-rm $(OUTPUT)
+	-rm $(OUTPUT) $(OUTPUT_DEV)
 
 $(OUTPUT): $(FILES)
-	zip $@ $(FILES)
+	zip $@ $^
+
+$(OUTPUT_DEV): $(FILES)
+	-mkdir build-dev
+	cp $^ build-dev/
+	plutil -replace bundleid -string "hu.lorentey.alfred.swift-evolution.dev" build-dev/Info.plist
+	plutil -replace name -string "Swift Evolution Proposals (development)" build-dev/Info.plist
+	zip --junk-paths $@ build-dev/*
+	rm build-dev/*
+	rmdir build-dev
+


### PR DESCRIPTION
This adds a new `make dev` command that builds a version of the Alfred workflow with a different name and bundle ID. This is useful for testing the workflow in Alfred during development without overwriting the production version.