### PR TITLE
Adopt new Swift Evolution metadata file format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /alfred-swift-evolution.alfredworkflow
+/alfred-swift-evolution-dev.alfredworkflow

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,25 @@
 OUTPUT = alfred-swift-evolution.alfredworkflow
+OUTPUT_DEV = alfred-swift-evolution-dev.alfredworkflow
 FILES = Info.plist se-lookup.swift icon.png
 
 all: $(OUTPUT)
 
+# Build a development version of the workflow with a different bundle ID.
+# Useful for testing changes in Alfred without replacing the production version.
+dev: $(OUTPUT_DEV)
+
 clean:
-	-rm $(OUTPUT)
+	-rm $(OUTPUT) $(OUTPUT_DEV)
 
 $(OUTPUT): $(FILES)
-	zip $@ $(FILES)
+	zip $@ $^
+
+$(OUTPUT_DEV): $(FILES)
+	-mkdir build-dev
+	cp $^ build-dev/
+	plutil -replace bundleid -string "hu.lorentey.alfred.swift-evolution.dev" build-dev/Info.plist
+	plutil -replace name -string "Swift Evolution Proposals (development)" build-dev/Info.plist
+	zip --junk-paths $@ build-dev/*
+	rm build-dev/*
+	rmdir build-dev
+

--- a/se-lookup.swift
+++ b/se-lookup.swift
@@ -227,7 +227,7 @@ extension AlfredItem {
     init(proposal: Proposal) {
         self.uid = proposal.url.absoluteString
         self.title = "\(proposal.id): \(proposal.title)"
-        self.subtitle = "\(proposal.status.description) • \(proposal.title)"
+        self.subtitle = "\(proposal.status.description)"
         self.arg = proposal.url.absoluteString
         self.autocomplete = proposal.id
         self.quicklookurl = proposal.url.absoluteString

--- a/se-lookup.swift
+++ b/se-lookup.swift
@@ -227,7 +227,14 @@ extension AlfredItem {
     init(proposal: Proposal) {
         self.uid = proposal.url.absoluteString
         self.title = "\(proposal.id): \(proposal.title)"
-        self.subtitle = "\(proposal.status.description)"
+        var subtitle = proposal.status.description
+        if let upcomingFeatureFlag = proposal.upcomingFeatureFlag {
+            subtitle.append(" · Feature flag: \(upcomingFeatureFlag.flag)")
+            if let languageMode = upcomingFeatureFlag.enabledInLanguageMode {
+                subtitle.append(" (enabled in Swift \(languageMode) language version)")
+            }
+        }
+        self.subtitle = subtitle
         self.arg = proposal.url.absoluteString
         self.autocomplete = proposal.id
         self.quicklookurl = proposal.url.absoluteString


### PR DESCRIPTION
This change adapts to schema version 1.0.0 of the Swift Evolution metadata file format, which went live on 2024-04-21 (with schema version "0.1.0" during the transition). For more info on the changes in the new schema, see James Dempsey’s posts at https://forums.swift.org/t/swift-evolution-metadata-transition/71387 and https://forums.swift.org/t/swift-evolution-metadata-proposed-changes/70779.

The old schema will stop working on 2024-07-22, so we need to ship an update before then.

Fixes #2.